### PR TITLE
Add photo permissions text and fix prod CI

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build:
+    name: Install and build production app
     runs-on: ubuntu-latest
     steps:
       - name: 🏗  Setup reo
@@ -52,5 +53,5 @@ jobs:
 
       - name: 🚀 Submit app
         run: |
-          envsubst < eas.json >> eas.json 
+          envsubst < eas.json > eas.tmp && mv eas.tmp eas.json
           eas submit --platform ios --latest --profile production

--- a/app.json
+++ b/app.json
@@ -31,7 +31,8 @@
       "buildNumber": "1.0.0",
       "infoPlist": {
         "NSMicrophoneUsageDescription": "Big Thoughts needs access to the microphone to record voice notes.",
-        "NSSpeechRecognitionUsageDescription": "Big Thoughts needs access to speech recognition for voice note transcription."
+        "NSSpeechRecognitionUsageDescription": "Big Thoughts needs access to speech recognition for voice note transcription.",
+        "NSPhotoLibraryUsageDescription": "Big Thoughts depends on a tool which requires the ability to request access to your photo library. Big Thoughts itself does not require nor use these permissions."
       }
     },
     "extra": {


### PR DESCRIPTION
# Problem
- Production CI fails because of `envsubst`
- App review rejected because `NSPhotoLibraryUsageDescription` may be requested by the codebase, but isn't in the ios info.plist

# Fix
- Fix envsubst
- Hard to find out which library can request photo library access but the app itself doesn't request this so the permission should not be used, even if the ability to request it is available. So just added to the info.plist